### PR TITLE
Fix updating the counter for different rules

### DIFF
--- a/WebApiThrottle/ThrottlingFilter.cs
+++ b/WebApiThrottle/ThrottlingFilter.cs
@@ -213,6 +213,7 @@ namespace WebApiThrottle
                                     content,
                                     QuotaExceededResponseCode,
                                     core.RetryAfterFrom(throttleCounter.Timestamp, rateLimitPeriod));
+                                break;
                             }
                         }
                     }


### PR DESCRIPTION
There is a bug on updating counter for all rules. If the smaller rule is reached, also the bigger rules were updating too. 
For example if we have PerHour = 1 and PerDay = 5. If you reach the hourly limit and continue making calls (6 for example) the second rule PerDay is also updated. And after one hour when you can make calls according the first rule you will get an error that the daily limit is reached